### PR TITLE
At first just touch up, but

### DIFF
--- a/src/main/scala/org/clulab/pdf2txt/apps/log/Ligature2logDir.scala
+++ b/src/main/scala/org/clulab/pdf2txt/apps/log/Ligature2logDir.scala
@@ -28,7 +28,7 @@ object Ligature2logDir extends App {
   class LoggingLanguageModel(languageModel: LanguageModel, logger: Logger) extends LanguageModel {
 
     override def shouldJoin(left: String, right: String, prevWords: Seq[String]): Boolean = {
-      val context = prevWords.mkString(" ") + (if (prevWords.nonEmpty) " " else "") + left + right
+      val context = prevWords.mkString(" ") + (if (prevWords.nonEmpty) " " else "") + "[" + left + right + "]"
       val result = languageModel.shouldJoin(left, right, prevWords)
 
       logger.log(left, right, result, context)

--- a/src/main/scala/org/clulab/pdf2txt/apps/log/LineBreak2logDir.scala
+++ b/src/main/scala/org/clulab/pdf2txt/apps/log/LineBreak2logDir.scala
@@ -27,7 +27,7 @@ object LineBreak2logDir extends App {
   class LoggingLanguageModel(languageModel: LanguageModel, logger: Logger) extends LanguageModel {
 
     override def shouldJoin(left: String, right: String, prevWords: Seq[String]): Boolean = {
-      val context = prevWords.mkString(" ") + (if (prevWords.nonEmpty) " " else "") + left + "-" + right
+      val context = prevWords.mkString(" ") + (if (prevWords.nonEmpty) " " else "") + "[" + left + "-" + right + "]"
       val result = languageModel.shouldJoin(left, right, prevWords)
 
       logger.log(left, right, result, context)

--- a/src/main/scala/org/clulab/pdf2txt/apps/log/WordBreakByHyphen2logDir.scala
+++ b/src/main/scala/org/clulab/pdf2txt/apps/log/WordBreakByHyphen2logDir.scala
@@ -23,7 +23,7 @@ object WordBreakByHyphen2logDir extends App {
   class LoggingLanguageModel(logger: Logger) extends NeverLanguageModel {
 
     override def shouldJoin(left: String, right: String, prevWords: Seq[String]): Boolean = {
-      val message = prevWords.mkString(" ") + (if (prevWords.nonEmpty) " " else "") + left + "-" + right
+      val message = prevWords.mkString(" ") + (if (prevWords.nonEmpty) " " else "") + "[" + left + right + "]"
 
       logger.log(message)
       super.shouldJoin(left, right, prevWords)

--- a/src/main/scala/org/clulab/pdf2txt/languageModel/ProbabilisticLanguageModel.scala
+++ b/src/main/scala/org/clulab/pdf2txt/languageModel/ProbabilisticLanguageModel.scala
@@ -7,8 +7,8 @@ class ProbabilisticLanguageModel extends LanguageModel {
   // We should check if P("dis"|"They decided to") is larger than P("disclose"|"They decided to").
   // If not, then the two tokens should be merged into one.
   override def shouldJoin(left: String, right: String, prevWords: Seq[String]): Boolean = {
-    val pCombined = p(left + right, prevWords)
     val pUncombined = p(left, prevWords)
+    val pCombined = p(left + right, prevWords)
 
     pCombined != 0f && pCombined >= pUncombined // Favor the combined unless we're already at 0.
   }

--- a/src/main/scala/org/clulab/pdf2txt/preprocessor/WordBreakByHyphenPreprocessor.scala
+++ b/src/main/scala/org/clulab/pdf2txt/preprocessor/WordBreakByHyphenPreprocessor.scala
@@ -13,8 +13,8 @@ class WordBreakByHyphenPreprocessor(languageModel: LanguageModel = WordBreakByHy
   def isSeparatedBySingleSpace(prevWordDocument: WordDocument, nextWordDocument: WordDocument): Boolean =
       StringUtils.LETTER_BREAK_CHARS.exists(prevWordDocument.postSeparator.matches)
 
-  def shouldJoin(left: String, right: String, prevWords: Seq[String]): Boolean =
-      languageModel.shouldJoin(left, right, prevWords)
+  def shouldJoin(left: String, middle: String, right: String, prevWords: Seq[String]): Boolean =
+      languageModel.shouldJoin(left + middle, right, prevWords)
 
   protected def preprocessSentence(sentence: SentenceDocument): TextRanges = {
     val processorsWords = sentence.contents.map(_.processorsWord)
@@ -24,13 +24,14 @@ class WordBreakByHyphenPreprocessor(languageModel: LanguageModel = WordBreakByHy
       val nextWord = sentence.contents(nextIndex)
 
       isHyphen(hyphenWord) && !isSeparated(prevWord) && isSeparatedBySingleSpace(hyphenWord, nextWord) &&
-          shouldJoin(prevWord.processorsWord, nextWord.processorsWord, processorsWords.take(prevIndex))
+          shouldJoin(prevWord.processorsWord, hyphenWord.processorsWord, nextWord.processorsWord, processorsWords.take(prevIndex))
     }
 
     tripleIndexOpt.map { case (prevIndex, currIndex, nextIndex) =>
       val prevWord = sentence.contents(prevIndex)
+      val currWord = sentence.contents(currIndex)
       val nextWord = sentence.contents(nextIndex)
-      val processorsWord = prevWord.processorsWord + nextWord.processorsWord
+      val processorsWord = prevWord.processorsWord + currWord.processorsWord + nextWord.processorsWord
       val textRanges = new TextRanges()
 
       textRanges += sentence.andBefore(prevWord.preSeparator)
@@ -55,4 +56,5 @@ class WordBreakByHyphenPreprocessor(languageModel: LanguageModel = WordBreakByHy
 
 object WordBreakByHyphenPreprocessor {
   lazy val languageModel = GigawordLanguageModel()
+  val HYPHEN_STRING = StringUtils.HYPHEN.toString
 }

--- a/src/test/scala/org/clulab/pdf2txt/preprocessor/LigaturePreprocessorTest.scala
+++ b/src/test/scala/org/clulab/pdf2txt/preprocessor/LigaturePreprocessorTest.scala
@@ -8,10 +8,11 @@ class LigaturePreprocessorTest extends Test {
   class TestLanguageModel(vocab: Map[String, Float]) extends ProbabilisticLanguageModel {
 
     override def p(nextWord: String, prevWords: Seq[String]): Float  = {
-      // val context = prevWords.mkString(" ")
+      val context = prevWords.mkString(" ")
+      val probability = vocab.getOrElse(nextWord, 0f)
 
-      // println(s"p($nextWord | $context)")
-      vocab.getOrElse(nextWord, 0)
+      println(s"p($nextWord | $context) = $probability")
+      probability
     }
   }
 
@@ -30,12 +31,15 @@ class LigaturePreprocessorTest extends Test {
 
   test(
     "fl our is not fl avored ij s but waffl es are, go fi gure, said at the cliff side.",
-    "flour is not flavored ij s but waffles are, go fi gure, said at the cliffside.",
-    Map("flour" -> 1, "flavored" -> 1, "ijs" -> 1, "waffles" -> 1, "cliffside" ->1)
+    "flour is not flavored ij s but waffl es are, go fi gure, said at the cliffside.",
+    Map(
+      "flour" -> 1, "flavored" -> 1, "ijs" -> 1, "waffles" -> 0.8f, "cliffside" -> 1,
+      "waffl" -> 0.9f
+    )
   )
   test (
     "A coe ffi cient is not dif fi cult to defi ne.",
     "A coefficient is not difficult to define.",
-    Map("coefficient" -> 1, "difficult" ->1, "define" -> 1)
+    Map("coefficient" -> 1, "difficult" -> 1, "define" -> 1)
   )
 }

--- a/src/test/scala/org/clulab/pdf2txt/preprocessor/WordBreakByHyphenPreprocessorTest.scala
+++ b/src/test/scala/org/clulab/pdf2txt/preprocessor/WordBreakByHyphenPreprocessorTest.scala
@@ -8,10 +8,11 @@ class WordBreakByHyphenPreprocessorTest extends Test {
   class TestLanguageModel(vocab: Map[String, Float]) extends ProbabilisticLanguageModel {
 
     override def p(nextWord: String, prevWords: Seq[String]): Float  = {
-      // val context = prevWords.mkString(" ")
+      val context = prevWords.mkString(" ")
+      val probability = vocab.getOrElse(nextWord, 0f)
 
-      // println(s"p($nextWord | $context)")
-      vocab.getOrElse(nextWord, 0)
+      println(s"p($nextWord | $context) = $probability")
+      probability
     }
   }
 
@@ -28,16 +29,19 @@ class WordBreakByHyphenPreprocessorTest extends Test {
     }
   }
 
-  test("I went in- to the store.", "I went into the store.", Map("into" -> 1))
-  test("Pre- hensile tails are un- common.", "Prehensile tails are uncommon.", Map("Prehensile" -> 1, "uncommon" -> 2))
   test(
-    "Once upon a time.  He went in- to and on- to the house.  They lived happily ever after.",
-    "Once upon a time.  He went into and onto the house.  They lived happily ever after.",
-    Map("into" -> 1f, "onto" -> 2f)
+    "Differences between left- and right- handedness.",
+    "Differences between left- and right-handedness.",
+    Map("right-handedness" -> 1)
   )
   test(
-    "It is a double- triple- quadruple threat.",
-    "It is a doubletriplequadruple threat.",
-    Map("doubletriple" -> 1f, "doubletriplequadruple" -> 2f)
+    "It is a five- year- old bicycle.",
+    "It is a five-year-old bicycle.",
+    Map("five-year" -> 1f, "five-year-old" -> 1f)
+  )
+  test(
+    "It is a five-year- old bicycle.",
+    "It is a five-year-old bicycle.",
+    Map("five-year" -> 1f, "five-year-old" -> 1f)
   )
 }

--- a/src/test/scala/org/clulab/pdf2txt/preprocessor/WordBreakBySpacePreprocessorTest.scala
+++ b/src/test/scala/org/clulab/pdf2txt/preprocessor/WordBreakBySpacePreprocessorTest.scala
@@ -8,10 +8,11 @@ class WordBreakBySpacePreprocessorTest extends Test {
   class TestLanguageModel(vocab: Map[String, Float]) extends ProbabilisticLanguageModel {
 
     override def p(nextWord: String, prevWords: Seq[String]): Float  = {
-      // val context = prevWords.mkString(" ")
+      val context = prevWords.mkString(" ")
+      val probability = vocab.getOrElse(nextWord, 0f)
 
-      // println(s"p($nextWord | $context)")
-      vocab.getOrElse(nextWord, 0)
+      println(s"p($nextWord | $context) = $probability")
+      probability
     }
   }
 


### PR DESCRIPTION
then change WordBreakByHyphen so that hyphen is not removed.  It should fix things like "left- handed" and "five- year- old".  Things like "in- to" will have come from the ends of lines and are handled elsewhere.